### PR TITLE
erm98 Implementar headers para los consumos de los servicios

### DIFF
--- a/src/hooks/useBusinessUnits.ts
+++ b/src/hooks/useBusinessUnits.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect } from "react";
 
 import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
-import { getBusinessUnitsForOfficer } from "@services/businessUnits/getBusinessUnits";
-import { useHeaders } from "@hooks/useHeaders";
 
 import { useErrorFlag } from "./useErrorFlag";
+import { businessUnitStaff } from "@src/mocks/staff/staff.mock";
+import { mapBusinessUnitsApiToEntity } from "@src/services/businessUnits/getBusinessUnits/mappers";
 
 const ERROR_CODE_EMPTY_DATA = 1006;
 const ERROR_CODE_FETCH_FAILED = 1008;
@@ -20,7 +20,6 @@ export const useBusinessUnits = (
   const [codeError, setCodeError] = useState<number | undefined>(undefined);
   const [isFetching, setIsFetching] = useState(false);
   const [flagShown, setFlagShown] = useState(false);
-  const { getHeaders } = useHeaders();
 
   useErrorFlag(flagShown);
 
@@ -36,16 +35,21 @@ export const useBusinessUnits = (
       return;
     }
 
-    const fetchBusinessUnits = async () => {
+    const fetchBusinessUnits = () => {
       setIsFetching(true);
 
       try {
-        const headers = await getHeaders();
+        /*const headers = await getHeaders();
 
-        const fetchedBusinessUnits = await getBusinessUnitsForOfficer(
+         const fetchedBusinessUnits = await getBusinessUnitsForOfficer(
           userAccount,
           portalPublicCode,
           headers,
+        ); */
+
+        // Simulación de datos obtenidos
+        const fetchedBusinessUnits = businessUnitStaff.map(
+          mapBusinessUnitsApiToEntity,
         );
 
         if (isMounted) {

--- a/src/hooks/useBusinessUnits.ts
+++ b/src/hooks/useBusinessUnits.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
+
 import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
 import { getBusinessUnitsForOfficer } from "@services/businessUnits/getBusinessUnits";
+import { useHeaders } from "@hooks/useHeaders";
 
 import { useErrorFlag } from "./useErrorFlag";
 
@@ -18,6 +20,7 @@ export const useBusinessUnits = (
   const [codeError, setCodeError] = useState<number | undefined>(undefined);
   const [isFetching, setIsFetching] = useState(false);
   const [flagShown, setFlagShown] = useState(false);
+  const { getHeaders } = useHeaders();
 
   useErrorFlag(flagShown);
 
@@ -37,9 +40,12 @@ export const useBusinessUnits = (
       setIsFetching(true);
 
       try {
+        const headers = await getHeaders();
+
         const fetchedBusinessUnits = await getBusinessUnitsForOfficer(
           userAccount,
           portalPublicCode,
+          headers,
         );
 
         if (isMounted) {

--- a/src/hooks/useDeleteRequest.ts
+++ b/src/hooks/useDeleteRequest.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 
 import { useErrorFlag } from "@hooks/useErrorFlag";
+import { useHeaders } from "@hooks/useHeaders";
 import { deleteHumanResourceRequest } from "@services/humanResourcesRequest/deleteHumanResourceRequest";
 
 export function useDeleteRequest<T extends { requestId?: string }>(
@@ -11,6 +12,7 @@ export function useDeleteRequest<T extends { requestId?: string }>(
   const location = useLocation();
   const [isDeleting, setIsDeleting] = useState(false);
   const [showFlag, setShowFlag] = useState(false);
+  const { getHeaders } = useHeaders();
 
   useErrorFlag(
     showFlag,
@@ -27,7 +29,8 @@ export function useDeleteRequest<T extends { requestId?: string }>(
   ) => {
     setIsDeleting(true);
     try {
-      await deleteHumanResourceRequest(id, justification, number);
+      const headers = await getHeaders();
+      await deleteHumanResourceRequest(id, justification, number, headers);
       updateStateFunction((item: T) => item[idField] !== id);
       setShowFlag(false);
       return true;

--- a/src/hooks/useEmployeeConsultation.ts
+++ b/src/hooks/useEmployeeConsultation.ts
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
+
 import { getAllEmployees } from "@services/employeeConsultation";
 import { Employee } from "@ptypes/employeePortalConsultation.types";
 import { useErrorFlag } from "@hooks/useErrorFlag";
+import { useHeaders } from "@hooks/useHeaders";
 
 interface UseAllEmployeesResult {
   employees: Employee[];
@@ -19,6 +21,7 @@ export const useAllEmployees = (
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState<number>(initialPage);
   const [perPage, setPerPage] = useState<number>(initialPerPage);
+  const { getHeaders } = useHeaders();
 
   useErrorFlag(!!error, error ?? undefined);
 
@@ -28,7 +31,8 @@ export const useAllEmployees = (
       setError(null);
 
       try {
-        const data = await getAllEmployees(fetchPage, fetchPerPage);
+        const headers = await getHeaders();
+        const data = await getAllEmployees(fetchPage, fetchPerPage, headers);
         setEmployees(data);
       } catch (err) {
         const errorMessage =

--- a/src/hooks/useHeaders.ts
+++ b/src/hooks/useHeaders.ts
@@ -1,0 +1,20 @@
+import { useAuth0 } from "@auth0/auth0-react";
+
+import { useAppContext } from "@context/AppContext";
+
+export const useHeaders = () => {
+  const { selectedClient, staffUser } = useAppContext();
+  const { getAccessTokenSilently } = useAuth0();
+
+  const getHeaders = async () => {
+    const accessToken = await getAccessTokenSilently();
+    return {
+      "Content-type": "application/json; charset=UTF-8",
+      "X-Business-unit": selectedClient?.name ?? "",
+      "X-User-Name": staffUser?.userAccount ?? "",
+      Authorization: `Bearer ${accessToken}`,
+    };
+  };
+
+  return { getHeaders };
+};

--- a/src/hooks/useRequestSubmissionAPI.ts
+++ b/src/hooks/useRequestSubmissionAPI.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { IRequestBody } from "@services/humanResourcesRequest/postHumanResourceRequest/types";
 import { postHumanResourceRequest } from "@services/humanResourcesRequest/postHumanResourceRequest";
+import { useHeaders } from "@hooks/useHeaders";
 
 export function useRequestSubmissionAPI() {
   const [showErrorFlag, setShowErrorFlag] = useState(false);
@@ -9,10 +10,12 @@ export function useRequestSubmissionAPI() {
   const [humanResourceRequestId, setHumanResourceRequestId] = useState<
     string | null
   >(null);
+  const { getHeaders } = useHeaders();
 
   const submitRequestToAPI = async (requestBody: IRequestBody) => {
     try {
-      const response = await postHumanResourceRequest(requestBody);
+      const headers = await getHeaders();
+      const response = await postHumanResourceRequest(requestBody, headers);
 
       if (response?.humanResourceRequestId) {
         setHumanResourceRequestId(response.humanResourceRequestId);

--- a/src/mocks/staff/staff.mock.tsx
+++ b/src/mocks/staff/staff.mock.tsx
@@ -28,4 +28,39 @@ const mockStaffMembers: IOption[] = [
   },
 ];
 
-export { mockStaffMembers };
+const businessUnitStaff = [
+  {
+    businessUnitPublicCode: "860514047",
+    languageId: "1111",
+    abbreviatedName: "SistemasEnLinea",
+    descriptionUse: "SistemasEnLinea",
+    firstMonthOfFiscalYear: "JAN",
+    urlLogo: "http://www.sistemasenlinea.com.co/images/logos/selsalogo2.png",
+  },
+  {
+    businessUnitPublicCode: "cooptraisspru",
+    languageId: "1111",
+    abbreviatedName: "cooptraisspru",
+    descriptionUse: "cooptraisspru",
+    firstMonthOfFiscalYear: "JAN",
+    urlLogo: "http://www.sistemasenlinea.com.co/images/nuevo-logo-linix.png",
+  },
+  {
+    businessUnitPublicCode: "test",
+    languageId: "1111",
+    abbreviatedName: "test",
+    descriptionUse: "test ",
+    firstMonthOfFiscalYear: "JAN",
+    urlLogo: "http://logo.png",
+  },
+  {
+    businessUnitPublicCode: "test2",
+    languageId: "1111",
+    abbreviatedName: "test2",
+    descriptionUse: "test2",
+    firstMonthOfFiscalYear: "JAN",
+    urlLogo: "http://logo.png",
+  },
+];
+
+export { mockStaffMembers, businessUnitStaff };

--- a/src/pages/Employees/NewEmployee/forms/AssignmentForm/hooks/useAssignmentOptions.ts
+++ b/src/pages/Employees/NewEmployee/forms/AssignmentForm/hooks/useAssignmentOptions.ts
@@ -3,6 +3,7 @@ import { IOption } from "@inubekit/inubekit";
 
 import { getRemunerationProfiles } from "@services/catalogs/getRemunerationProfiles";
 import { useErrorFlag } from "@hooks/useErrorFlag";
+import { useHeaders } from "@hooks/useHeaders";
 
 import { mapProfilesToOptions } from "../utils/mappers";
 
@@ -11,6 +12,7 @@ export const useAssignmentOptions = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [hasError, setHasError] = useState<number | null>(null);
   const [flagShown, setFlagShown] = useState(false);
+  const { getHeaders } = useHeaders();
 
   useErrorFlag(flagShown, "Error obteniendo las opciones de asignación");
 
@@ -21,7 +23,8 @@ export const useAssignmentOptions = () => {
       setFlagShown(false);
 
       try {
-        const remunerationProfiles = await getRemunerationProfiles();
+        const headers = await getHeaders();
+        const remunerationProfiles = await getRemunerationProfiles(headers);
         setAssignmentOptions(mapProfilesToOptions(remunerationProfiles));
       } catch (err) {
         setHasError(500);

--- a/src/pages/certifications/index.tsx
+++ b/src/pages/certifications/index.tsx
@@ -5,6 +5,7 @@ import { useMediaQuery } from "@inubekit/inubekit";
 import { useErrorFlag } from "@hooks/useErrorFlag";
 import { useDeleteRequest } from "@hooks/useDeleteRequest";
 import { getHumanResourceRequests } from "@services/humanResourcesRequest/getHumanResourcesRequest";
+import { useHeaders } from "@hooks/useHeaders";
 
 import { CertificationsOptionsUI } from "./interface";
 import { certificationsNavConfig } from "./config/nav.config";
@@ -17,13 +18,19 @@ function CertificationsOptions() {
   const [isLoading, setIsLoading] = useState(true);
   const [tableData, setTableData] = useState<ICertificationsTable[]>([]);
   const isMobile = useMediaQuery("(max-width: 768px)");
+  const { getHeaders } = useHeaders();
 
   useEffect(() => {
     const fetchHumanResourceRequests = async () => {
       setIsLoading(true);
 
       try {
-        const requests = await getHumanResourceRequests("certification", "");
+        const headers = await getHeaders();
+        const requests = await getHumanResourceRequests(
+          "certification",
+          "",
+          headers,
+        );
         const formattedData = formatHumanResourceData(requests ?? []);
         setTableData(formattedData);
       } catch (error) {

--- a/src/pages/holidays/index.tsx
+++ b/src/pages/holidays/index.tsx
@@ -5,6 +5,7 @@ import { useMediaQuery } from "@inubekit/inubekit";
 import { getHumanResourceRequests } from "@services/humanResourcesRequest/getHumanResourcesRequest";
 import { useDeleteRequest } from "@hooks/useDeleteRequest";
 import { useErrorFlag } from "@hooks/useErrorFlag";
+import { useHeaders } from "@hooks/useHeaders";
 
 import { formatHolidaysData } from "./config/table.config";
 import { HolidaysOptionsUI } from "./interface";
@@ -15,6 +16,7 @@ function HolidaysOptions() {
   const navigate = useNavigate();
   const location = useLocation();
   const isMobile = useMediaQuery("(max-width: 768px)");
+  const { getHeaders } = useHeaders();
 
   const [isLoading, setIsLoading] = useState(true);
   const [tableData, setTableData] = useState<IHolidaysTable[]>([]);
@@ -28,7 +30,8 @@ function HolidaysOptions() {
   const fetchHolidaysData = async () => {
     setIsLoading(true);
     try {
-      const requests = await getHumanResourceRequests("vacations", "");
+      const headers = await getHeaders();
+      const requests = await getHumanResourceRequests("vacations", "", headers);
       setTableData(formatHolidaysData(requests ?? []));
 
       if (location.state?.showFlag) {

--- a/src/services/businessUnits/getBusinessUnits/index.tsx
+++ b/src/services/businessUnits/getBusinessUnits/index.tsx
@@ -22,6 +22,7 @@ class BusinessUnitsError extends Error {
 const getBusinessUnitsForOfficer = async (
   userAccount: string,
   portalPublicCode: string,
+  headers: Record<string, string>,
 ): Promise<IBusinessUnit[]> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
@@ -34,8 +35,8 @@ const getBusinessUnitsForOfficer = async (
       const options: RequestInit = {
         method: "GET",
         headers: {
+          ...headers,
           "X-Action": "SearchBusinessUnitsForAnOfficerLinpar",
-          "Content-Type": "application/json; charset=UTF-8",
         },
         signal: controller.signal,
       };

--- a/src/services/catalogs/getRemunerationProfiles/index.tsx
+++ b/src/services/catalogs/getRemunerationProfiles/index.tsx
@@ -11,7 +11,9 @@ export interface IRemunerationProfile {
   regulatoryFrameworkCode: string;
 }
 
-const getRemunerationProfiles = async (): Promise<IRemunerationProfile[]> => {
+const getRemunerationProfiles = async (
+  headers: Record<string, string>,
+): Promise<IRemunerationProfile[]> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
 
@@ -25,7 +27,7 @@ const getRemunerationProfiles = async (): Promise<IRemunerationProfile[]> => {
         {
           method: "GET",
           headers: {
-            "Content-type": "application/json; charset=UTF-8",
+            ...headers,
           },
           signal: controller.signal,
         },

--- a/src/services/employeeConsultation/index.tsx
+++ b/src/services/employeeConsultation/index.tsx
@@ -8,7 +8,11 @@ import { Employee } from "@ptypes/employeePortalConsultation.types";
 
 import { mapEmployeeApiToEntity } from "./mappers";
 
-const getAllEmployees = async (page = 1, perPage = 50): Promise<Employee[]> => {
+const getAllEmployees = async (
+  page = 1,
+  perPage = 50,
+  headers: Record<string, string>,
+): Promise<Employee[]> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
 
@@ -27,9 +31,8 @@ const getAllEmployees = async (page = 1, perPage = 50): Promise<Employee[]> => {
       const options: RequestInit = {
         method: "GET",
         headers: {
+          ...headers,
           "X-Action": "SearchAllEmployee",
-          "X-Business-Unit": environment.BUSINESS_UNIT ?? "",
-          "Content-type": "application/json; charset=UTF-8",
         },
         signal: controller.signal,
       };

--- a/src/services/humanResourcesRequest/deleteHumanResourceRequest/index.tsx
+++ b/src/services/humanResourcesRequest/deleteHumanResourceRequest/index.tsx
@@ -7,6 +7,7 @@ export async function deleteHumanResourceRequest(
   id: string,
   justification: string,
   number: string,
+  headers: Record<string, string>,
 ): Promise<IDeleteResponse> {
   const body = mapRequestBody(id, justification, number);
   const response = await fetch(
@@ -14,7 +15,7 @@ export async function deleteHumanResourceRequest(
     {
       method: "DELETE",
       headers: {
-        "Content-Type": "application/json",
+        ...headers,
         "X-Action": "RemoveHumanResourcesRequest",
       },
       body: JSON.stringify(body),

--- a/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
+++ b/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
@@ -3,11 +3,13 @@ import {
   maxRetriesServices,
   environment,
 } from "@config/environment";
+
 import { mapHumanResourceRequestApiToEntity } from "./mappers";
 
 const getHumanResourceRequests = async (
   typeRequest: string,
   employeeId: string,
+  headers: Record<string, string>,
 ) => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
@@ -26,7 +28,7 @@ const getHumanResourceRequests = async (
         {
           method: "GET",
           headers: {
-            "Content-type": "application/json; charset=UTF-8",
+            ...headers,
           },
           signal: controller.signal,
         },

--- a/src/services/humanResourcesRequest/postHumanResourceRequest/index.tsx
+++ b/src/services/humanResourcesRequest/postHumanResourceRequest/index.tsx
@@ -1,16 +1,17 @@
-import { IRequestBody, IHumanResourceResponse } from "./types";
-
 import { environment } from "@config/environment";
+
+import { IRequestBody, IHumanResourceResponse } from "./types";
 
 export async function postHumanResourceRequest(
   requestBody: IRequestBody,
+  headers: Record<string, string>,
 ): Promise<IHumanResourceResponse> {
   const response = await fetch(
     `${environment.IVITE_IHUREM_PERSISTENCE_PROCESS_SERVICE}/human-resources-requests`,
     {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        ...headers,
       },
       body: JSON.stringify(requestBody),
     },


### PR DESCRIPTION
Implement the following headers:

X-Business-unit: Obtained from the context, the selected business unit (selectedClient -> name).
X-User-Name: Obtained from the context, the selected staff member (staffUser -> userAccount).
Authorization: Temporarily from Auth0 -> getAccessTokenSilently.
For all services being consumed.
Acceptance criteria:

The following headers must be displayed in all requests.

_**3 services running in App.tsx, which provide business unit data and employee information (Headers data). The headers were not implemented in these cases due to the application being killed and hooks being used outside of the AppProvider.**_