### PR TITLE
erm122 Ajustar visualización para registros vacíos en vacaciones y certificaciones

### DIFF
--- a/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
+++ b/src/services/humanResourcesRequest/getHumanResourcesRequest/index.tsx
@@ -37,6 +37,11 @@ const getHumanResourceRequests = async (
         },
       );
 
+      if (res.status === 204) {
+        clearTimeout(timeoutId);
+        return [];
+      }
+
       clearTimeout(timeoutId);
 
       if (!res.ok) {


### PR DESCRIPTION
fix: When querying for certifications or vacations, a FLAG is displayed when there is no data, but this should not display this FLAG.