### PR TITLE
erm168 Actualizar días pendientes cuando se realiza una solicitud de vacaciones

### DIFF
--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import {
   Nav,
   Grid,
@@ -65,6 +65,7 @@ function AppPage(props: AppPageProps) {
   } = useAppContext();
   const isTablet = useMediaQuery("(max-width: 944px)");
   const navigate = useNavigate();
+  const location = useLocation();
 
   const navConfig = useNavConfig(optionForCustomerPortal ?? []);
   const configHeader = useConfigHeader(optionForCustomerPortal ?? []);
@@ -74,7 +75,7 @@ function AppPage(props: AppPageProps) {
   const collapseMenuRef = useRef<HTMLDivElement>(null);
   const businessUnitChangeRef = useRef<HTMLDivElement>(null);
 
-  const { vacationDays, loadingDays } = useEmployeeVacationDays(
+  const { vacationDays, loadingDays, refetch } = useEmployeeVacationDays(
     selectedEmployee?.employeeId ?? null,
   );
   const totalDays =
@@ -113,6 +114,12 @@ function AppPage(props: AppPageProps) {
   const toggleModal = () => {
     setIsModalOpen(!isModalOpen);
   };
+
+  useEffect(() => {
+    if (location.pathname.includes("/holidays")) {
+      refetch();
+    }
+  }, [location.pathname]);
 
   return (
     <StyledAppPage>


### PR DESCRIPTION
Pending days must be updated in the banner widget when an employee or staff member makes a request.

When an employee or staff member makes a vacation or pay request in the attendance system and is redirected to the query in progress.
The service that calculates the pending days must be re-queried.
Acceptance criteria:
All of the following criteria must be met:

There must be no compilation or execution errors.
The pending days, subtracted from the request's pending days, must be displayed in the widget.