### PR TITLE
at/erm231/include-menu-icon-from-the-database

### DIFF
--- a/src/services/staffPortal/getOptionForCustomerPortal/mappers.ts
+++ b/src/services/staffPortal/getOptionForCustomerPortal/mappers.ts
@@ -9,12 +9,14 @@ const mapOptionForCustomerPortalApiToEntity = (
     optionStaffId: resend.optionStaffId as string,
     parentOptionId: resend.parentOptionId as string,
     publicCode: resend.publicCode as string,
+    iconReference: resend.iconReference as string,
     subOption: Array.isArray(resend.subOption)
       ? resend.subOption.map((subOption) => ({
           abbreviatedName: subOption.abbreviatedName as string,
           descriptionUse: subOption.descriptionUse as string,
           optionStaffId: subOption.optionStaffId as string,
           publicCode: subOption.publicCode as string,
+          iconReference: subOption.iconReference as string,
           subOption: subOption.subOption as string[],
           useCaseName: subOption.useCaseName as string,
         }))

--- a/src/types/staffPortalBusiness.types.ts
+++ b/src/types/staffPortalBusiness.types.ts
@@ -48,6 +48,7 @@ interface ISubOption {
 interface IOptionWithSubOptions {
   abbreviatedName: string;
   descriptionUse: string;
+  iconReference: string;
   optionStaffId: string;
   parentOptionId: string;
   publicCode: string;


### PR DESCRIPTION
## 📋 Descripción

Se agregó el campo iconReference tanto en el mapper como en el type correspondiente, con el fin de soportar la nueva referencia de íconos en el sistema.

## 🛠 Cambios realizados

- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [ ] Refactorización
- [ ] Actualización de dependencias
- [ ] Mejoras de rendimiento
- [ ] Otros (especificar)

## 🚦 ¿Cómo probar?

Ir al archivo donde se define el mapper.

Verificar que el campo iconReference se esté asignando correctamente desde la respuesta de la API hacia la entidad interna.

Revisar en el type correspondiente que el nuevo campo exista.

Probar la ejecución normal del flujo que consume este mapper para confirmar que no hay errores en consola.

mockoon 
url
isaas-query-process-service/api/staff-portals-by-business-manager
body
[
  {
    "abbreviatedName": "Incapacidades",
    "descriptionUse": "Incapacidades",
    "optionStaffId": "08489ba9-2484-4549-ab52-f0f11a4b7ccd",
    "parentOptionId": null,
    "publicCode": "incapacidadesPortalErm",
    "iconReference": "",
    "subOption": [],
    "useCaseName": ""
  }
]


## ✅ Checklist - Estandar

- [ ] El código sigue la guía de estilos
- [ ] Se agregaron/actualizaron pruebas unitarias (Si aplica cuando se crea en el storybook)
- [ ] No se introducen errores en consola
- [ ] Se probó en dispositivos/resoluciones relevantes (Si aplica)

## 📕 Checklist - Criterios de aceptacion

El campo iconReference debe estar disponible en el type.

El campo iconReference debe mapearse correctamente desde la API en el mapper.

La aplicación debe seguir funcionando sin errores en consola.

## 📚 Referencias

https://github.com/orgs/selsa-inube/projects/17/views/1?filterQuery=-status%3ABacklog+label%3A"app%3A+erm-portal"&pane=issue&itemId=125357266&issue=selsa-inube%7Cteam-codex%7C231
 