### PR TITLE
at/erm248/adjust-Isaas-by-removing-references

### DIFF
--- a/src/components/layout/AppPage/config.ts
+++ b/src/components/layout/AppPage/config.ts
@@ -3,7 +3,7 @@ import { IBusinessManager } from "@ptypes/employeePortalBusiness.types";
 
 export const mockDataPortal: IStaffPortalByBusinessManager = {
   abbreviatedName: "Test Name",
-  businessManagerId: "12345",
+  businessManagerCode: "12345",
   descriptionUse: "Test description",
   optionsByStaffPortalBusinessManager: [],
   publicCode: "ABC123",
@@ -14,8 +14,9 @@ export const mockDataPortal: IStaffPortalByBusinessManager = {
   employeePortalId: "EP123",
   staffPortalId: "SP123",
 };
+
 export const mockBusinessManagersData: IBusinessManager = {
-  id: "1",
+  businessManagerCode: "BM001",
   publicCode: "BM001",
   language: "es",
   abbreviatedName: "Gerente 1",
@@ -23,6 +24,8 @@ export const mockBusinessManagersData: IBusinessManager = {
   urlBrand: "https://example.com/brand.png",
   urlLogo: "https://example.com/logo.png",
   customerId: "C001",
+  clientId: "CL001",
+  clientSecret: "SECRET1",
 };
 
 export const mockBusinessUnitsData = [

--- a/src/context/AppContext/index.tsx
+++ b/src/context/AppContext/index.tsx
@@ -86,7 +86,7 @@ function AppProvider(props: AppProviderProps) {
 
   const [provisionedPortal, setProvisionedPortal] =
     useState<IStaffPortalByBusinessManager>(dataPortal);
-  const [businessManagers, setBusinessManagers] =
+  const [businessManager, setBusinessManager] =
     useState<IBusinessManager>(businessManagersData);
   const [businessUnits, setBusinessUnits] =
     useState<IBusinessUnit[]>(businessUnitsData);
@@ -205,8 +205,8 @@ function AppProvider(props: AppProviderProps) {
         setProvisionedPortal,
         staffUser,
         setStaffUser,
-        businessManagers,
-        setBusinessManagers,
+        businessManager,
+        setBusinessManager,
         businessUnits,
         setBusinessUnits,
         businessUnitsIsFetching,

--- a/src/context/AppContext/types.ts
+++ b/src/context/AppContext/types.ts
@@ -5,19 +5,9 @@ import {
   IStaffPortalByBusinessManager,
   IStaffUserAccount,
 } from "@ptypes/staffPortalBusiness.types";
+import { IBusinessManager } from "@ptypes/employeePortalBusiness.types";
 import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
 import { Employee } from "@ptypes/employeePortalConsultation.types";
-
-interface BusinessManager {
-  id: string;
-  publicCode: string;
-  language: string;
-  abbreviatedName: string;
-  description: string;
-  urlBrand: string;
-  urlLogo: string;
-  customerId: string;
-}
 
 export interface IStaffUseCasesData {
   listOfUseCases: string[];
@@ -57,8 +47,8 @@ export interface IAppContextType {
   >;
   staffUser: IStaffUserAccount;
   setStaffUser: React.Dispatch<React.SetStateAction<IStaffUserAccount>>;
-  businessManagers: BusinessManager | null;
-  setBusinessManagers: React.Dispatch<React.SetStateAction<BusinessManager>>;
+  businessManager: IBusinessManager;
+  setBusinessManager: React.Dispatch<React.SetStateAction<IBusinessManager>>;
   businessUnits: IBusinessUnit[];
   setBusinessUnits: React.Dispatch<React.SetStateAction<IBusinessUnit[]>>;
   businessUnitsIsFetching: boolean;

--- a/src/hooks/useBusinessManagers.ts
+++ b/src/hooks/useBusinessManagers.ts
@@ -4,7 +4,7 @@ import {
   IBusinessManager,
   IEmployeePortalByBusinessManager,
 } from "@ptypes/employeePortalBusiness.types";
-import { getBusinessManagerById } from "@services/businessManagers/getBusinessManagerById";
+import { getBusinessManagerByCode } from "@services/businessManagers/getBusinessManagerByCode";
 
 import { useErrorFlag } from "./useErrorFlag";
 
@@ -22,12 +22,12 @@ export const useBusinessManagers = (
 
   useEffect(() => {
     const fetchBusinessManagers = async () => {
-      if (!portalPublicCode?.businessManagerId) return;
+      if (!portalPublicCode?.businessManagerCode) return;
 
       setIsFetching(true);
       try {
-        const fetchedBusinessManagers = await getBusinessManagerById(
-          portalPublicCode.businessManagerId,
+        const fetchedBusinessManagers = await getBusinessManagerByCode(
+          portalPublicCode.businessManagerCode,
         );
 
         if (

--- a/src/mocks/staff/staff.mock.tsx
+++ b/src/mocks/staff/staff.mock.tsx
@@ -91,7 +91,7 @@ const optionMenuStaff = [
     publicCode: "PortalErm",
     abbreviatedName: "Portal ERM Gestion humanas",
     descriptionUse: "A traves de este portal se gestionan los empleados",
-    businessManagerId: "598a8ec2-8725-48ac-b592-b23cdd54ec30",
+    businessManagerCode: "598a8ec2-8725-48ac-b592-b23cdd54ec30",
     staffPortalCatalogId: "d70c5ddc-02c1-443d-970b-e3913ffe6458",
     url: "https://images.jpg",
     optionsByStaffPortalBusinessManager: [

--- a/src/pages/Employees/SelectEmployee/index.tsx
+++ b/src/pages/Employees/SelectEmployee/index.tsx
@@ -32,13 +32,13 @@ function SelectEmployeePage() {
     handleSubmit,
   } = useSelectEmployee();
 
-  const { businessManagers, selectedClient, setStaffUseCasesData } =
+  const { businessManager, selectedClient, setStaffUseCasesData } =
     useAppContext();
   const id = JSON.parse(
     localStorage.getItem("staffUser") ?? "{}",
   ).identificationDocumentNumber;
 
-  const publicCode = businessManagers?.publicCode ?? "";
+  const publicCode = businessManager?.publicCode ?? "";
   const clientId = selectedClient?.id ?? "";
 
   const { data } = useStaffUseCases(publicCode, clientId, id);

--- a/src/services/businessManagers/getBusinessManagerByCode/index.tsx
+++ b/src/services/businessManagers/getBusinessManagerByCode/index.tsx
@@ -8,8 +8,8 @@ import { IBusinessManager } from "@ptypes/employeePortalBusiness.types";
 
 import { mapBusinessManagerApiToEntity } from "./mappers";
 
-const getBusinessManagerById = async (
-  businessManagerId: string,
+const getBusinessManagerByCode = async (
+  businessManagerCode: string,
 ): Promise<IBusinessManager> => {
   const maxRetries = maxRetriesServices;
   const fetchTimeout = fetchTimeoutServices;
@@ -22,14 +22,14 @@ const getBusinessManagerById = async (
       const options: RequestInit = {
         method: "GET",
         headers: {
-          "X-Action": "SearchByIdBusinessManager",
+          "X-Action": "SearchAllBusinessManager",
           "Content-type": "application/json; charset=UTF-8",
         },
         signal: controller.signal,
       };
 
       const res = await fetch(
-        `${environment.IVITE_ISAAS_QUERY_PROCESS_SERVICE}/business-managers/${businessManagerId}`,
+        `${environment.IVITE_ISAAS_QUERY_PROCESS_SERVICE}/business-managers?businessManagerCode=${businessManagerCode}`,
         options,
       );
 
@@ -49,7 +49,11 @@ const getBusinessManagerById = async (
         };
       }
 
-      return mapBusinessManagerApiToEntity(data);
+      // si el servicio devuelve un array, tomar el primero
+      const businessManager =
+        Array.isArray(data) && data.length > 0 ? data[0] : data;
+
+      return mapBusinessManagerApiToEntity(businessManager);
     } catch (error) {
       if (attempt === maxRetries) {
         throw new Error(
@@ -58,7 +62,6 @@ const getBusinessManagerById = async (
           }`,
         );
       }
-
       continue;
     }
   }
@@ -66,4 +69,4 @@ const getBusinessManagerById = async (
   return {} as IBusinessManager;
 };
 
-export { getBusinessManagerById };
+export { getBusinessManagerByCode };

--- a/src/services/businessManagers/getBusinessManagerByCode/mappers.ts
+++ b/src/services/businessManagers/getBusinessManagerByCode/mappers.ts
@@ -11,7 +11,7 @@ const mapBusinessManagerApiToEntity = (
   };
 
   const business: IBusinessManager = {
-    id: toStringSafe(businessManager.businessManagerId),
+    businessManagerCode: toStringSafe(businessManager.businessManagerCode),
     publicCode: toStringSafe(businessManager.publicCode),
     language: toStringSafe(businessManager.languageId),
     abbreviatedName: toStringSafe(businessManager.abbreviatedName),
@@ -19,7 +19,10 @@ const mapBusinessManagerApiToEntity = (
     urlBrand: toStringSafe(businessManager.urlBrand),
     urlLogo: toStringSafe(businessManager.urlLogo),
     customerId: toStringSafe(businessManager.customerId),
+    clientId: toStringSafe(businessManager.clientId),
+    clientSecret: toStringSafe(businessManager.clientSecret),
   };
+
   return business;
 };
 

--- a/src/services/staffPortal/StaffPortalByBusinessManager/mappers.ts
+++ b/src/services/staffPortal/StaffPortalByBusinessManager/mappers.ts
@@ -6,9 +6,9 @@ const mapStaffPortalByBusinessManagerApiToEntity = (
   const buildResend: IStaffPortalByBusinessManager = {
     abbreviatedName:
       typeof resend.abbreviatedName === "string" ? resend.abbreviatedName : "",
-    businessManagerId:
-      typeof resend.businessManagerId === "string"
-        ? resend.businessManagerId
+    businessManagerCode:
+      typeof resend.businessManagerCode === "string"
+        ? resend.businessManagerCode
         : "",
     descriptionUse:
       typeof resend.descriptionUse === "string" ? resend.descriptionUse : "",

--- a/src/types/employeePortalBusiness.types.ts
+++ b/src/types/employeePortalBusiness.types.ts
@@ -15,7 +15,7 @@ interface IOptionsByEmployeePortalBusinessManager {
 
 interface IEmployeePortalByBusinessManager {
   abbreviatedName: string;
-  businessManagerId: string;
+  businessManagerCode: string;
   businessUnit: string;
   descriptionUse: string;
   portalCode: string;
@@ -25,7 +25,7 @@ interface IEmployeePortalByBusinessManager {
 }
 
 interface IBusinessManager {
-  id: string;
+  businessManagerCode: string;
   publicCode: string;
   language: string;
   abbreviatedName: string;
@@ -33,6 +33,8 @@ interface IBusinessManager {
   urlBrand: string;
   urlLogo: string;
   customerId: string;
+  clientId: string;
+  clientSecret: string;
 }
 
 export enum EContractStatus {


### PR DESCRIPTION
## 📋 Descripción

Se ajusta el servicio de consulta de `BusinessManager` para que utilice `businessManagerCode` en lugar de `businessManagerId`.  
Además, se actualizó el header a `SearchAllBusinessManager` y se agregó el query param `businessManagerCode` en la llamada al servicio.  
Se ajustó el mapper y la interface correspondientes para reflejar este cambio.

## 🛠 Cambios realizados

- [ ] Nueva funcionalidad
- [ ] Corrección de bug
- [x] Refactorización
- [ ] Actualización de dependencias
- [ ] Mejoras de rendimiento
- [ ] Otros (especificar)

## 🚦 ¿Cómo probar?

1. Ir a la sección que consume el hook `useBusinessManagers`.
2. Validar que se realice la petición al endpoint con el query param:  
   `/business-managers?businessManagerCode={codigo}`.
3. Confirmar que los datos del `BusinessManager` se mapeen y rendericen correctamente.
4. En caso de error o datos vacíos, se debe mostrar el `Flag` correspondiente con el código de error (1006 o 1007).

## ✅ Checklist - Estandar

- [x] El código sigue la guía de estilos
- [ ] Se agregaron/actualizaron pruebas unitarias (Si aplica cuando se crea en el storybook)
- [x] No se introducen errores en consola
- [x] Se probó en dispositivos/resoluciones relevantes (Si aplica)

## 📕 Checklist - Criterios de aceptacion

- La consulta al servicio debe realizarse con `businessManagerCode` en lugar de `businessManagerId`.
- El header de la petición debe ser `SearchAllBusinessManager`.
- El mapper y la interface deben reflejar el campo `businessManagerCode`.
- En caso de error o datos vacíos, se debe mostrar el `Flag` con el código de error correspondiente.

## 📚 Referencias

[248](https://github.com/orgs/selsa-inube/projects/17/views/1?filterQuery=-status%3ABacklog+label%3A"app%3A+erm-portal"&pane=issue&itemId=127414344&issue=selsa-inube%7Cteam-codex%7C248)
